### PR TITLE
more explicit request + prevent jQuery conflicts

### DIFF
--- a/Drupal_Module/demandbase/demandbase_client.inc
+++ b/Drupal_Module/demandbase/demandbase_client.inc
@@ -70,10 +70,13 @@ class demandbase_client {
       $ip = $ip_address;
     }
 	
-	$options = array(
-		'key' 	=> $this->dbkey,
-		'query' => $ip
-	);
+	$data = 'key='.$this->dbkey.'&query='.$ip;
+
+  $options = array(
+    'method' => 'GET', // HTTP Request Type
+    'data' => $data, // Parameters
+    'headers' => array('Content-Type' => 'application/x-www-form-urlencoded'),
+  );
 	
     $result = drupal_http_request($this->url, $options); //JB 12/20/2013 - POST returns 'unauthorized' use GET instead (similar to JS method)
     $this->code = json_decode($result->code);

--- a/Drupal_Module/demandbase/js/demandbaseIPWidget.js
+++ b/Drupal_Module/demandbase/js/demandbaseIPWidget.js
@@ -3,7 +3,7 @@ Name: Demandbase IP Widget
 Authora: Matthew Downs (mdowns[at]demandbase[dot]com)
 License: Copyright 2012. This code may not be reused without explicit permission by its owners. All rights reserved.
 ***/
-
+(function($){
 var DemandbaseLabs = {};
 DemandbaseLabs.IPWidget = {
   ipWidget : null,
@@ -252,5 +252,5 @@ DemandbaseLabs.IPWidget = {
   }  //end initIpWidget
 } //end DemandbaseLabs.IPWidget
 
-
+})(jQuery);
 


### PR DESCRIPTION
- I was getting _Unauthorized_ response for result data in Demandase Show IP tab.  The parameters passed are now more explicit and result data is displayed.

- jQuery conflict was making https://drupal.org/project/admin_menu a popular admin menu for Drupal disappear